### PR TITLE
PLAT-125601 Fix a grep command to ignore certain directories

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,18 @@ const getValidFiles = (modules, pattern = '*.js') => {
 	const files = [];
 
 	modules.forEach(moduleConfig => {
-		const grepCmd = `grep -r -l "@module" ${moduleConfig.path} --exclude-dir={build,node_modules,sampler,samples,tests,dist,coverage} --include=${pattern}`;
+		const grepCmd = `
+			grep -r -l "@module" \
+				${moduleConfig.path} \
+				--exclude-dir=build \
+				--exclude-dir=node_modules \
+				--exclude-dir=sampler \
+				--exclude-dir=samples \
+				--exclude-dir=tests \
+				--exclude-dir=dist \
+				--exclude-dir=coverage \
+				--include=${pattern}
+		`;
 		const moduleFiles = shelljs.exec(grepCmd, {silent: true});
 		Array.prototype.push.apply(files, moduleFiles.stdout.trim().split('\n'));
 	});


### PR DESCRIPTION
Fix a grep command to ignore certain directories when scanning the file to be documented

Enact-DCO-1.0-Signed-off-by: Jeongran Jang jeongran.jang@lge.com