### PR TITLE
WRN-17841: @link not working properly in jsdocs

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "homepage": "https://github.com/enactjs/docs-utils#readme",
   "dependencies": {
     "chalk": "^4.1.2",
-    "documentation": "^13.2.5",
+    "documentation": "^12.3.0",
     "elasticlunr": "^0.9.5",
     "gray-matter": "^4.0.3",
     "jsonata": "^1.8.5",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "markdown-toc": "^1.2.0",
     "minimist": "^1.2.5",
     "mkdirp": "^1.0.4",
-    "progress": "^2.0.3",
+    "progress": "^1.1.8",
     "readdirp": "^2.2.1",
     "shelljs": "^0.8.4"
   },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "elasticlunr": "^0.9.5",
     "gray-matter": "^4.0.3",
     "jsonata": "^1.8.5",
-    "jsonfile": "^6.1.0",
+    "jsonfile": "^5.0.0",
     "markdown-toc": "^1.2.0",
     "minimist": "^1.2.5",
     "mkdirp": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -34,15 +34,15 @@
   "homepage": "https://github.com/enactjs/docs-utils#readme",
   "dependencies": {
     "chalk": "^4.1.2",
-    "documentation": "^12.3.0",
+    "documentation": "13.2.1",
     "elasticlunr": "^0.9.5",
     "gray-matter": "^4.0.3",
     "jsonata": "^1.8.5",
-    "jsonfile": "^5.0.0",
+    "jsonfile": "^6.1.0",
     "markdown-toc": "^1.2.0",
     "minimist": "^1.2.5",
     "mkdirp": "^1.0.4",
-    "progress": "^1.1.8",
+    "progress": "^2.0.3",
     "readdirp": "^2.2.1",
     "shelljs": "^0.8.4"
   },


### PR DESCRIPTION
### Issue Resolved / Feature Added
@link not working properly in jsdocs

### Resolution
Downgrade the documentation npm module to  13.2.1

### Additional Considerations

### Links
WRN-17841

### Comments
Enact-DCO-1.0-Signed-off-by: SJ RO (sj.ro@lge.com)