### PR TITLE
WRP0-9019 : Modify description of minimum node version requirement for docs-utils 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact docs-utils module, newest changes on the top.
 
+## [unreleased]
+
+### ⚠ BREAKING CHANGE
+
+- Require node 14 or later from 0.4.0 version
+
 ## [0.4.0] - 2022-10-20
 
 - Update dependency with documentation 14.0.0 (require node 14 or later)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@ The following is a curated list of changes in the Enact docs-utils module, newes
 ## [0.4.0] - 2022-10-20
 
 - Update dependency with documentation 14.0.0
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,9 @@ The following is a curated list of changes in the Enact docs-utils module, newes
 
 ## [unreleased]
 
-### ⚠ BREAKING CHANGE
-
-- Require node 14 or later from 0.4.0 version
+- Changed to require node 14 or later
 
 ## [0.4.0] - 2022-10-20
 
-- Update dependency with documentation 14.0.0
+- Updated dependency with documentation 14.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,5 +10,4 @@ The following is a curated list of changes in the Enact docs-utils module, newes
 
 ## [0.4.0] - 2022-10-20
 
-- Update dependency with documentation 14.0.0 (require node 14 or later)
-
+- Update dependency with documentation 14.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,5 +4,5 @@ The following is a curated list of changes in the Enact docs-utils module, newes
 
 ## [0.4.0] - 2022-10-20
 
-- Update dependency with documentation 14.0.0
+- Update dependency with documentation 14.0.0 (require node 14 or later)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Utilities for parsing and validating JSDoc
 
-**Note:** Requires Node 10.10+.
+**Note:** Requires Node 14+.
 
 ## Standalone Usage
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Utilities for parsing and validating JSDoc in Enact projects",
   "version": "0.4.0",
   "engines": {
-    "node": ">=10.10.0"
+    "node": ">=14"
   },
   "main": "index.js",
   "bin": {


### PR DESCRIPTION


### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Documents related to docs-utils 0.4.0 need to be updated for minimum node version requirements. 
Because docs-utils 0.4.0 has its dependency updated to documentationjs 14.0.0 or higher

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Update CHANGLOG.md, README.md and package.json to announce the minimum node version. 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRP-9019

### Comments
Enact-DCO-1.0-Signed-off-by: SJ RO (sj.ro@lge.com)