### PR TITLE
WRQ-203: Fixed to find the exact path containing keyword when searching docs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The following is a curated list of changes in the Enact docs-utils module, newes
 
 ## [unreleased]
 
-- Fixed to find page URL containing keyword when searching docs.
+- Fixed to find the exact path containing keyword when searching docs.
 
 ## [0.4.6] - 2023-09-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The following is a curated list of changes in the Enact docs-utils module, newest changes on the top.
 
+## [unreleased]
+
+- Fixed to find page URL containing keyword when searching docs.
+
 ## [0.4.6] - 2023-09-21
 
 - Updated dependencies.

--- a/index.js
+++ b/index.js
@@ -638,7 +638,7 @@ function generateIndex (docIndexFile) {
 			const title = data.data.title || pathModule.parse(filename).name;
 			let result = '';
 			if (pathModule.parse(filename).name !== 'index') {
-				result = filename.replace(/(.md)$/,'');
+				result = filename.replace(/(.md)$/, '');
 			} else {
 				result = pathModule.dirname(filename);
 			}

--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ const getValidFiles = (modules, pattern = '*.js') => {
  * @param {boolean} noSave - If `true`, no files are written to disk
  * @returns {Promise[]} - An array of promises that represent the scanning process
  */
-const getDocumentation = (paths, strict, noSave) => {
+const getDocumentation = async (paths, strict, noSave) => {
 	const docOutputPath = pathModule.join('src', 'pages', 'docs', 'modules');
 	// TODO: Add @module to all files and scan files and combine json
 	const validPaths = paths.reduce((prev, path) => {
@@ -109,8 +109,9 @@ const getDocumentation = (paths, strict, noSave) => {
 	const bar = new ProgressBar('Parsing: [:bar] (:current/:total) :file',
 		{total: validPaths.size, width: 20, complete: '#', incomplete: ' '});
 
-	validPaths.forEach(async function (path) {
-		await generateDocumentationResponse();
+	await generateDocumentationResponse();
+
+	validPaths.forEach(function (path) {
 		// TODO: If we do change it to scan each file rather than directory we need to fix componentDirectory matching
 		let componentDirectory;
 		if (os.platform() === 'win32') {
@@ -636,6 +637,7 @@ function generateIndex (docIndexFile) {
 			const filename = entry.fullPath;
 			const data = matter.read(filename);
 			const title = data.data.title || pathModule.parse(filename).name;
+
 			let result = '';
 			if (pathModule.parse(filename).name !== 'index') {
 				result = filename.replace(/(.md)$/, '');

--- a/index.js
+++ b/index.js
@@ -640,7 +640,7 @@ function generateIndex (docIndexFile) {
 
 			let result = '';
 			if (pathModule.parse(filename).name !== 'index') {
-				result = filename.replace(/(.md)$/, '');
+				result = filename.replace(/(\.md)$/, '');
 			} else {
 				result = pathModule.dirname(filename);
 			}

--- a/index.js
+++ b/index.js
@@ -620,6 +620,7 @@ function generateIndex (docIndexFile) {
 				// the ref (id). Include both the human-readable title and the path to the doc
 				// in the ref so we can parse it later for display.
 				doc.id = `${doc.title}|docs/modules/${doc.title}`;
+				index.addDoc(doc);
 			} catch (ex) {
 				console.log(chalk.red(`Error parsing ${entry.path}`));
 				console.log(chalk.red(ex));
@@ -635,7 +636,13 @@ function generateIndex (docIndexFile) {
 			const filename = entry.fullPath;
 			const data = matter.read(filename);
 			const title = data.data.title || pathModule.parse(filename).name;
-			const id = `${title}|${pathModule.relative('src/pages/', pathModule.dirname(filename))}`;
+			let result = '';
+			if (pathModule.parse(filename).name !== 'index') {
+				result = filename.replace(/(.md)$/,'');
+			} else {
+				result = pathModule.dirname(filename);
+			}
+			const id = `${title}|${pathModule.relative('src/pages/', result)}`;
 
 			try {
 				index.addDoc({id, title, description: data.content});


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
1. When searching, the link is directed to the parent URL rather than the page URL containing the keyword.
2. The library API not appearing in search results.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
1. Modify the path when creating an index for elasticlunr search.
2. Fixed incorrectly modified part in the previous PR(https://github.com/enactjs/docs-utils/pull/17)
  => Restore the `index.addDoc(doc);` line
    Fixed incorrectly modified part in the previous PR(https://github.com/enactjs/docs-utils/pull/16)
  => Change order the `await generateDocumentationResponse()' To execute generateIndex() after getDocumentation()

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
- Reference for elasticlunr : http://elasticlunr.com/docs/index.html

### Links
[//]: # (Related issues, references)
WRQ-203

### Comments
Enact-DCO-1.0-Signed-off-by: SJ RO (sj.ro@lge.com)